### PR TITLE
eslint: downgrade prettier violations to warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,8 @@
   "plugins": ["react", "prettier"],
   "rules": {
     "react/react-in-jsx-scope": "off",
-    "react/prop-types": 0
+    "react/prop-types": 0,
+    "prettier/prettier": "warn"
   },
   "settings": {
     "react": {


### PR DESCRIPTION
**What?**
This PR updates the ESLint config to treat Prettier violations as warnings instead of errors:

```json
 "rules": {
    "react/react-in-jsx-scope": "off",
    "react/prop-types": 0,
    "prettier/prettier": "warn"      <-- The addition
  }
```

**Why?**
Currently, minor whitespace or formatting issues reported by Prettier stop the React app from compiling. This interrupts development unnecessarily, especially for trivial violations such as extra spaces or line breaks.

**Expected results**
By downgrading these issues to warnings:
- The app will continue to build and run during development.
- Formatting feedback is still visible in the console.
- Developers are not blocked by non-functional style concerns.

**Note**
This is a suggested change we should decide whether we prefer strict enforcement (blocking builds) or not. Further, it is a trivial PR meant to test the process.