### PR TITLE
ESlint: Downgrade prettier violations to warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "react/prop-types": 0,
-    "prettier/prettier": ["error", { "endOfLine": "auto" }]
+    "prettier/prettier": ["warn", { "endOfLine": "auto" }]
   },
   "settings": {
     "react": {


### PR DESCRIPTION
**What?**
This PR updates the ESLint config to treat Prettier violations as warnings instead of errors:

```json
 "rules": {
    "react/react-in-jsx-scope": "off",
    "react/prop-types": 0,
    "prettier/prettier": "warn"      <-- The addition
  }
```

**Why?**
Currently, minor whitespace or formatting issues reported by Prettier stop the React app from compiling. This interrupts development unnecessarily, especially for trivial violations such as extra spaces or line breaks.

**Expected results**
By downgrading these issues to warnings:
- The app will continue to build and run during development.
- Formatting feedback is still visible in the console.
- Developers are not blocked by non-functional style concerns.

**Note**
This is a suggested change we should decide whether we prefer strict enforcement (blocking builds) or not. I suggest that we set up a github action that runs a linter on PR/push. Further, this is a trivial PR meant to test the process.