### PR TITLE
localStorage for 'token' and 'user' on sign up and login.

### DIFF
--- a/src/context/auth.js
+++ b/src/context/auth.js
@@ -48,11 +48,11 @@ const AuthProvider = ({ children }) => {
     localStorage.removeItem('token');
     localStorage.removeItem('user');
     setToken(null);
+    setUser(null);
   };
 
   const handleRegister = async (email, password) => {
     const res = await register(email, password);
-    console.log(res);
     setToken(res.data.token);
     setUser(res.data.user);
 

--- a/src/context/auth.js
+++ b/src/context/auth.js
@@ -36,10 +36,12 @@ const AuthProvider = ({ children }) => {
       return navigate('/login');
     }
 
-    localStorage.setItem('user', JSON.stringify(res.data.user));
+    const { passwordHash, ...userData } = res.data.user;
+
+    localStorage.setItem('user', JSON.stringify(userData));
     localStorage.setItem('token', res.data.token);
 
-    setUser(res.data.user);
+    setUser(userData);
     setToken(res.data.token);
     navigate(location.state?.from?.pathname || '/');
   };
@@ -53,20 +55,22 @@ const AuthProvider = ({ children }) => {
 
   const handleRegister = async (email, password) => {
     const res = await register(email, password);
-    setToken(res.data.token);
-    setUser(res.data.user);
+    const { passwordHash, ...userData } = res.data.user;
 
-    localStorage.setItem('user', JSON.stringify(res.data.user));
+    localStorage.setItem('user', JSON.stringify(userData));
     localStorage.setItem('token', res.data.token);
+
+    setUser(userData);
+    setToken(res.data.token);
+
     navigate('/verification');
   };
 
   const handleCreateProfile = async (firstName, lastName, githubUrl, bio) => {
-    const { userId } = jwt_decode(token);
-
-    await createProfile(userId, firstName, lastName, githubUrl, bio);
+    await createProfile(user.id, firstName, lastName, githubUrl, bio);
 
     localStorage.setItem('token', token);
+    localStorage.setItem('user', JSON.stringify(user));
     navigate('/');
   };
 

--- a/src/context/auth.js
+++ b/src/context/auth.js
@@ -7,7 +7,7 @@ import useAuth from '../hooks/useAuth';
 import { createProfile, login, register } from '../service/apiClient';
 
 // eslint-disable-next-line camelcase
-import jwt_decode from 'jwt-decode';
+// import jwt_decode from 'jwt-decode';
 
 const AuthContext = createContext();
 
@@ -15,7 +15,21 @@ const AuthProvider = ({ children }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [token, setToken] = useState(null);
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState({
+    bio: '',
+    email: '',
+    endDate: '',
+    firstName: '',
+    githubUrl: '',
+    id: -1,
+    lastName: '',
+    mobile: '',
+    photo: '',
+    role: 0,
+    specialism: '',
+    startDate: '',
+    username: ''
+  });
 
   useEffect(() => {
     const storedToken = localStorage.getItem('token');
@@ -67,10 +81,19 @@ const AuthProvider = ({ children }) => {
   };
 
   const handleCreateProfile = async (firstName, lastName, githubUrl, bio) => {
-    await createProfile(user.id, firstName, lastName, githubUrl, bio);
+    const updatedUser = {
+      ...user,
+      firstName,
+      lastName,
+      githubUrl,
+      bio
+    };
+    setUser(updatedUser);
 
     localStorage.setItem('token', token);
-    localStorage.setItem('user', JSON.stringify(user));
+    localStorage.setItem('user', JSON.stringify(updatedUser));
+
+    await createProfile(updatedUser.id, firstName, lastName, githubUrl, bio);
     navigate('/');
   };
 

--- a/src/context/auth.js
+++ b/src/context/auth.js
@@ -19,7 +19,7 @@ const AuthProvider = ({ children }) => {
 
   useEffect(() => {
     const storedToken = localStorage.getItem('token');
-    const storedUser = localStorage.getItem('user');
+    const storedUser = JSON.parse(localStorage.getItem('user'));
     if (storedToken && !token) {
       setToken(storedToken);
       navigate(location.state?.from?.pathname || '/');
@@ -36,7 +36,7 @@ const AuthProvider = ({ children }) => {
       return navigate('/login');
     }
 
-    localStorage.setItem('user', res.data.user);
+    localStorage.setItem('user', JSON.stringify(res.data.user));
     localStorage.setItem('token', res.data.token);
 
     setUser(res.data.user);
@@ -56,9 +56,8 @@ const AuthProvider = ({ children }) => {
     setToken(res.data.token);
     setUser(res.data.user);
 
-    localStorage.setItem('user', res.data.user);
+    localStorage.setItem('user', JSON.stringify(res.data.user));
     localStorage.setItem('token', res.data.token);
-
     navigate('/verification');
   };
 

--- a/src/context/auth.js
+++ b/src/context/auth.js
@@ -15,12 +15,17 @@ const AuthProvider = ({ children }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [token, setToken] = useState(null);
+  const [user, setUser] = useState(null);
 
   useEffect(() => {
     const storedToken = localStorage.getItem('token');
+    const storedUser = localStorage.getItem('user');
     if (storedToken && !token) {
       setToken(storedToken);
       navigate(location.state?.from?.pathname || '/');
+    }
+    if (storedUser && !user) {
+      setUser(storedUser);
     }
   }, [token, location.state?.from?.pathname, navigate]);
 
@@ -31,20 +36,28 @@ const AuthProvider = ({ children }) => {
       return navigate('/login');
     }
 
+    localStorage.setItem('user', res.data.user);
     localStorage.setItem('token', res.data.token);
 
+    setUser(res.data.user);
     setToken(res.data.token);
     navigate(location.state?.from?.pathname || '/');
   };
 
   const handleLogout = () => {
     localStorage.removeItem('token');
+    localStorage.removeItem('user');
     setToken(null);
   };
 
   const handleRegister = async (email, password) => {
     const res = await register(email, password);
+    console.log(res);
     setToken(res.data.token);
+    setUser(res.data.user);
+
+    localStorage.setItem('user', res.data.user);
+    localStorage.setItem('token', res.data.token);
 
     navigate('/verification');
   };
@@ -60,6 +73,7 @@ const AuthProvider = ({ children }) => {
 
   const value = {
     token,
+    user,
     onLogin: handleLogin,
     onLogout: handleLogout,
     onRegister: handleRegister,


### PR DESCRIPTION
Previously, localStorage was only updated on login.  
Additionally, it only added a data for `token`.

Now we set localStorage for both `token` and `user` from the `login` endpoint in backend, and make sure this is done when registering a new user (signing up) and logging in.