### PR TITLE
Issue(#124): `onBlur`-prop was never called on TextInput fields.

### DIFF
--- a/src/components/form/textInput/index.js
+++ b/src/components/form/textInput/index.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import EyeIcon from '../../../assets/icons/eyeicon';
 
 const TextInput = ({
-  value,
+  value = '',
   onChange,
   onKeyDown,
   name,
@@ -11,13 +11,18 @@ const TextInput = ({
   type = 'text',
   className,
   placeholder = '',
-  onBlur = null,
+  onBlur: onBlurProp, // rename to avoid shadowing event param onBlur
   disabled = false,
   maxLength = 280
 }) => {
   const [isFocused, setIsFocused] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const showIcon = icon && !(isFocused || value);
+
+  const handleBlur = (e) => {
+    setIsFocused(false);
+    onBlurProp?.(e);
+  };
 
   if (type === 'password') {
     return (
@@ -26,13 +31,13 @@ const TextInput = ({
 
         <div className="inputWithButton">
           <input
-            onBlur={onBlur}
             id={name}
             type={showPassword ? 'text' : type}
             name={name}
             value={value}
             onChange={onChange}
             onKeyDown={onKeyDown}
+            onBlur={handleBlur}
             autoComplete={type === 'password' ? 'current-password' : undefined}
             className={className}
             disabled={disabled}
@@ -66,7 +71,7 @@ const TextInput = ({
           onKeyDown={onKeyDown}
           className={className}
           placeholder={placeholder}
-          onBlur={onBlur}
+          onBlur={handleBlur}
           disabled={disabled}
           maxLength={maxLength}
           style={{ width: '100%', resize: 'vertical' }}
@@ -92,7 +97,7 @@ const TextInput = ({
         className={className}
         disabled={disabled}
         onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
+        onBlur={handleBlur}
       />
       {showIcon && <span className="icon">{icon}</span>}
     </div>


### PR DESCRIPTION
`onBlur={() => setIsFocused(false)}` shadowed the onBlur that supposedly was there a couple of days ago. Anyways, created:
```js
  const handleBlur = (e) => {
    setIsFocused(false);
    onBlurProp?.(e);
  };
```

So that we can have multiple methods being called on the `onBlur` event param.