### PR TITLE
146 - Pagination bug

### DIFF
--- a/src/pages/search/StudentSearchView.jsx
+++ b/src/pages/search/StudentSearchView.jsx
@@ -62,6 +62,7 @@ const StudentSearchView = () => {
 
   const onChange = (e) => {
     setSearchVal(e.target.value);
+    setCurrentPage(1);
   };
 
   return (


### PR DESCRIPTION
Same as https://github.com/boolean-uk/team-dev-client-team-3/pull/146 but with a bug fix.


### Problem
- Page did not reload when typing in the `Search for people` box causing weird bugs.
  - Example: You could be on page 9 when there were actually just 2 pages for the current search.

### Fix:
- Update onChange function to set the current page to 1.