### PR TITLE
Linter Config: Fix so that it actually lints whitespace.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,16 @@
     "react/react-in-jsx-scope": "off",
     "react/prop-types": 0,
     "prettier/prettier": ["warn", { "endOfLine": "auto" }],
-    "no-unused-vars": "warn"
+    "no-unused-vars": "warn",
+    "react/jsx-tag-spacing": [
+      "warn",
+      {
+        "closingSlash": "never",
+        "beforeSelfClosing": "always",
+        "afterOpening": "never",
+        "beforeClosing": "never"
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/package.json
+++ b/package.json
@@ -21,15 +21,9 @@
     "build": "react-scripts build",
     "test": "npx playwright test",
     "eject": "react-scripts eject",
-    "lint": "eslint .",
-    "lint:fix": "eslint --fix",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "eslint ./src --fix --ext .js,.jsx,.ts,.tsx",
     "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
   },
   "browserslist": {
     "production": [

--- a/src/components/loader/Loader.jsx
+++ b/src/components/loader/Loader.jsx
@@ -1,5 +1,5 @@
 import { FiLoader } from 'react-icons/fi';
-import './style.css'; 
+import './style.css';
 
 function Loader({ isLoading }) {
   if (isLoading) {

--- a/src/pages/cohort/CohortPage.jsx
+++ b/src/pages/cohort/CohortPage.jsx
@@ -48,7 +48,7 @@ const CohortPage = () => {
                   marginBottom: '1rem'
                 }}
               >
-                <ProfileCircle fullName={student} showMenu={false}/>
+                <ProfileCircle fullName={student} showMenu={false} />
                 <p style={{ marginLeft: '0.5rem' }}>{student}</p>
               </div>
             ))}

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -82,7 +82,7 @@ const ProfilePage = () => {
   };
 
   if (isLoading) {
-    return <Loader isLoading={isLoading}/>
+    return <Loader isLoading={isLoading} />;
   }
 
   return (


### PR DESCRIPTION
Added rule:
```json
"react/jsx-tag-spacing": [
      "warn",
      {
        "closingSlash": "never",
        "beforeSelfClosing": "always",
        "afterOpening": "never",
        "beforeClosing": "never"
      }
    ]
```
Because space wasn't linted.

Changed `npm lint` to only look in `./src` and only for react files:
`"lint:fix": "eslint ./src --fix --ext .js,.jsx,.ts,.tsx",`