### PR TITLE
Fixed navigation after editing profile

### DIFF
--- a/src/context/auth.js
+++ b/src/context/auth.js
@@ -171,9 +171,7 @@ const AuthProvider = ({ children }) => {
       const res = await patchProfile(updatedUserData.id, body);
       if (!res.ok) {
         console.error('Failed to Patch profile:', res.json());
-        return;
       }
-      navigate('/');
     } catch (err) {
       console.error('Failed to Patch profile:', err);
     }


### PR DESCRIPTION
The navigation is now removed when a profile is edited and updated. After clicking save, the user remains in the profile view